### PR TITLE
fixed incorrect variable which caused a crash

### DIFF
--- a/library/zerotier.py
+++ b/library/zerotier.py
@@ -207,7 +207,7 @@ class ZeroTierNode(object):
                 self.result['changed'] = True
                 return True
         except Exception as e:
-            self.module.fail_json(changed=False, msg="Unable to set config of ZeroTier node " + self.node, reason=str(e))
+            self.module.fail_json(changed=False, msg="Unable to set config of ZeroTier node " + self.nodename, reason=str(e))
 
     def getNodeConfig(self, network):
         """


### PR DESCRIPTION
When you exceed the number of "authorised" nodes within zerotier, your attempt to register is rejected with a "payment required" message.

At which stage the script bombs out with an error due to self.node when it should be (I think) self.nodename

simple fix
